### PR TITLE
fix: Fix build being unable to find name 'Cheerio' on node 14

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -241,7 +241,7 @@ function printMetadata(metadata: IssueMetadata | null): string | null {
     name: string,
     value: any | null,
     text: string,
-    f?: (li: Cheerio) => Cheerio
+    f?: (li: cheerio.Cheerio) => cheerio.Cheerio
   ) => {
     if (!f) f = (li) => li;
     if (value !== null) {


### PR DESCRIPTION
```
$ npm run test

> toktok-bugz@1.0.0 test /projects/toktok/js-bugz
> jest --coverage

FAIL test/index.test.ts
  ● Test suite failed to run

    src/index.ts:244:14 - error TS2304: Cannot find name 'Cheerio'.

    244     f?: (li: Cheerio) => Cheerio
                     ~~~~~~~
    src/index.ts:244:26 - error TS2304: Cannot find name 'Cheerio'.

    244     f?: (li: Cheerio) => Cheerio
                                 ~~~~~~~
```